### PR TITLE
fetching to-do from chrome storage on opening extension close#18

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,23 @@
 var id = 0;
 var list = [];
 $(function () {
+  chrome.storage.sync.get("todo", function (item) {
+    if (item.todo) {
+      if (item.todo.length > 0) {
+        var length = item.todo.length;
+        var last_id = item.todo[length - 1].id;
+        id = last_id;
+        list = item.todo;
+        list.map((item) => {
+          var list = document.createElement("li");
+          list.className +=
+            "list-group-item text-capitalize d-flex justify-content-between my-2";
+          list.textContent = item.task;
+          document.getElementById("list").appendChild(list);
+        });
+      }
+    }
+  });
   $("#add-task").click(function () {
     var task = $("#task-value").val();
     if (task) {


### PR DESCRIPTION
# Pull Request Template
## Mention the Issue Number you solved
> *18* 
## Added feature or fixed bugs ?
- [x] Feature added
- [ ] Bugs fixed
## What ?
> *Before this change the user was only able to store the todo through chrome storage API and when again opens the extension was not fetching the to-do from the API*
## Why ?
> *Now through this PR the extension is fetching the stored to-do from the API and showing them in as list items*
## Testing
> *I tested this by adding some to-do and then closing the extension and then opening the extension after some time to see if the data is being fetched or not*
## Screenshots
Current | Updated
--------|----------
![s1](https://user-images.githubusercontent.com/51486348/101912754-33a78480-3be8-11eb-9abc-d408f5671d89.PNG)|![s2](https://user-images.githubusercontent.com/51486348/101912788-3c985600-3be8-11eb-98b0-9823cf62f2e6.PNG)

## Additional Info
> *anything else you want to mention*

Join the [Gitter](https://gitter.im/the-browser-toolbox/community) channel to discuss about your pull request.
